### PR TITLE
#1 added fullscreen link above map preview

### DIFF
--- a/ckanext/cesiumpreview/theme/public/preview_cesium.js
+++ b/ckanext/cesiumpreview/theme/public/preview_cesium.js
@@ -54,23 +54,32 @@ ckan.module('cesiumpreview', function (jQuery, _) {
                 }
             config["initSources"][0]['catalog'][0]['items'][0]['type'] = preload_resource['format'].toLowerCase();
 
-            if (config["initSources"][0]['catalog'][0]['items'][0]['type'] == 'wms' || config["initSources"][0]['catalog'][0]['items'][0]['type'] == 'wfs') {
+            if (config["initSources"][0]['catalog'][0]['items'][0]['type'] == 'wms' || 
+		config["initSources"][0]['catalog'][0]['items'][0]['type'] == 'wfs') {
                 // if wms_layer specified in resource, display that layer/layers by default
                 if (typeof preload_resource['wms_layer'] != 'undefined' && preload_resource['wms_layer'] != '') {
                     config["initSources"][0]['catalog'][0]['items'][0]['layers'] = preload_resource['wms_layer'];
                 }
                 else {
-                    config["initSources"][0]['catalog'][0]['items'][0]['type'] = config["initSources"][0]['catalog'][0]['items'][0]['type'] + '-getCapabilities';
+                    config["initSources"][0]['catalog'][0]['items'][0]['type'] = config["initSources"][0]['catalog'][0]['items'][0]['type'] + 
+		    '-getCapabilities';
                 }
             }
-            if (config["initSources"][0]['catalog'][0]['items'][0]['type'] == 'aus-geo-csv' || config["initSources"][0]['catalog'][0]['items'][0]['type'] == 'csv-geo-au') {
+            if (config["initSources"][0]['catalog'][0]['items'][0]['type'] == 'aus-geo-csv' || 
+		config["initSources"][0]['catalog'][0]['items'][0]['type'] == 'csv-geo-au') {
                 config["initSources"][0]['catalog'][0]['items'][0]['type'] = 'csv';
             }
             var encoded_config = encodeURIComponent(JSON.stringify(config));
             var style = 'height: 600px; width: 100%; border: none;';
             var display = 'allowFullScreen mozAllowFullScreen webkitAllowFullScreen';
 
-            var html = '<iframe src="' + vis_server + '#clean&hideExplorerPanel=1&start=' + encoded_config + '" style="' + style + '" ' + display + '></iframe>';
+
+	    var src = vis_server + '#clean&hideExplorerPanel=1&start=' + encoded_config
+      	    var btn = '<a id="cesium-fullscreen" type="button" class="btn btn-warning" href="' + src + 
+	              '" title="Open map full-screen in a new tab" target="_"' + 
+		      '><i class="icon-fullscreen"></i>View Map Full-Screen</a>'
+            var map = '<iframe src="' + src  + '" style="' + style + '" ' + display + '></iframe>';
+	    var html = btn + map
 
             console.log(html);
 


### PR DESCRIPTION
## What
Added "View fullscreen" link above the map preview, which opens the NationalMap resource preview in a new tab.

## Where
E.g. [wms preview](http://catalogue.beta.data.wa.gov.au/dataset/lgate-036/resource/a0bbac97-b3e3-46f0-bb3f-171b66137b5d) of http://catalogue.beta.data.wa.gov.au/dataset/lgate-036/

## Why
The NM preview is already fullscreen inside the comparably small resource preview iframe, so the desired "view map preview fullscreen" means we need to "open NMap's 'share...' url in a new tab".

## Next
* Style: The CKAN resources don't seem to be available to cesium-preview's JS module, so for the time being this is an unstyled link.
* Content: Would be nice to have a slim title bar above the fullscreen map in a new tab, showing basic resource information like resource title and description, possibly some CKAN branding. This would add context to turn the full screen map into a "Custom map product". E.g. the resource title is "Awesome ZXYX Explorer" and the description offers some guidance how to interpret the shown (multiple) resources. See my ideas in datagovau/ckanext-cesiumpreview#1.